### PR TITLE
Fix plugin store loading

### DIFF
--- a/src/plugins/plugin_manager.py
+++ b/src/plugins/plugin_manager.py
@@ -159,9 +159,19 @@ class PluginManager(QObject):
 
     def _load_store_plugins(self):
         """Load store plugins."""
-        # TODO: Implement loading store plugins from a remote source
-        # For now, we'll just use a hardcoded list
+        # Try to load available plugins from a local JSON file. This avoids the
+        # need for a network connection during testing while still providing
+        # predictable data for the UI and unit tests.
         self.store_plugins = []
+        store_file = os.path.join(os.path.dirname(__file__), "store_plugins.json")
+        if os.path.exists(store_file):
+            try:
+                with open(store_file, "r", encoding="utf-8") as f:
+                    self.store_plugins = json.load(f)
+            except Exception as e:
+                self.app_controller.logger.error(
+                    f"Failed to load store plugins: {e}", exc_info=True
+                )
 
     def get_plugin(self, plugin_id):
         """Get a plugin by ID."""

--- a/src/plugins/store_plugins.json
+++ b/src/plugins/store_plugins.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "sample_plugin",
+    "name": "Sample Plugin",
+    "version": "1.0.0",
+    "author": "NebulaFusion Team",
+    "description": "A sample plugin that demonstrates adding a button to the toolbar.",
+    "url": "https://example.com/sample_plugin.zip"
+  }
+]


### PR DESCRIPTION
## Summary
- load plugin store from a bundled JSON file
- provide sample plugin data as `store_plugins.json`

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/test_plugin_system.py::TestPluginSystem::test_plugin_manager -vv` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6844563bef3c8328bcc1ca1a8afcb3dc