### PR TITLE
Fix plugin activation order

### DIFF
--- a/src/core/application.py
+++ b/src/core/application.py
@@ -156,6 +156,11 @@ class Application(QObject):
         self.plugin_loader.initialize()
         self.plugin_manager.initialize()
 
+        # Load and enable plugins before creating the UI so hooks like
+        # onToolbarCreated and onBrowserStart fire correctly during startup.
+        self.logger.info("Loading and enabling plugins...")
+        self._initialize_plugins()
+
         # Initialize theme manager
         self.logger.info("Initializing theme manager...")
         self.theme_manager.initialize()
@@ -172,13 +177,9 @@ class Application(QObject):
             self.logger.error("Main window could not be created.")
             return False
 
-        # Trigger browser start hook
+        # Trigger browser start hook after plugins are enabled
         self.logger.info("Triggering browser start hook...")
         self.hook_registry.trigger_hook("onBrowserStart")
-
-        # Load and enable plugins
-        self.logger.info("Loading and enabling plugins...")
-        self._initialize_plugins()
 
         # Update state
         self._is_initialized_flag = True

--- a/src/plugins/my_toolbar_button_plugin/__init__.py
+++ b/src/plugins/my_toolbar_button_plugin/__init__.py
@@ -15,12 +15,32 @@ class Plugin(PluginBase):
         super().__init__(api)
 
     def activate(self):
-        """Activate the plugin."""
-        return True
+        """Activate the plugin and register hooks."""
+        try:
+            self.api.hooks.register_hook(
+                "onToolbarCreated", self.plugin_id, self.onToolbarCreated
+            )
+            # If the toolbar is already available, trigger the hook immediately
+            main_window = getattr(self.api.app_controller, "main_window", None)
+            if main_window and getattr(main_window, "toolbar", None):
+                self.onToolbarCreated()
+            return True
+        except Exception as e:
+            self.api.logger.error(
+                f"Failed to activate My Toolbar Button Plugin: {e}"
+            )
+            return False
 
     def deactivate(self):
-        """Deactivate the plugin."""
-        return True
+        """Deactivate the plugin and unregister hooks."""
+        try:
+            self.api.hooks.unregister_all_hooks(self.plugin_id)
+            return True
+        except Exception as e:
+            self.api.logger.error(
+                f"Failed to deactivate My Toolbar Button Plugin: {e}"
+            )
+            return False
 
     def onToolbarCreated(self):
         """Called when the browser's toolbar is created."""

--- a/src/plugins/plugin_manager.py
+++ b/src/plugins/plugin_manager.py
@@ -159,9 +159,19 @@ class PluginManager(QObject):
 
     def _load_store_plugins(self):
         """Load store plugins."""
-        # TODO: Implement loading store plugins from a remote source
-        # For now, we'll just use a hardcoded list
+        # Try to load available plugins from a local JSON file. This avoids the
+        # need for a network connection during testing while still providing
+        # predictable data for the UI and unit tests.
         self.store_plugins = []
+        store_file = os.path.join(os.path.dirname(__file__), "store_plugins.json")
+        if os.path.exists(store_file):
+            try:
+                with open(store_file, "r", encoding="utf-8") as f:
+                    self.store_plugins = json.load(f)
+            except Exception as e:
+                self.app_controller.logger.error(
+                    f"Failed to load store plugins: {e}", exc_info=True
+                )
 
     def get_plugin(self, plugin_id):
         """Get a plugin by ID."""

--- a/src/plugins/quick_search_plugin/__init__.py
+++ b/src/plugins/quick_search_plugin/__init__.py
@@ -16,10 +16,26 @@ class Plugin(PluginBase):
         self.search_action = None
 
     def activate(self):
-        return True
+        """Activate the plugin and register hooks."""
+        try:
+            self.api.hooks.register_hook(
+                "onBrowserStart", self.plugin_id, self.onBrowserStart
+            )
+            return True
+        except Exception as e:
+            self.api.logger.error(f"Failed to activate Quick Search plugin: {e}")
+            return False
 
     def deactivate(self):
-        return True
+        """Deactivate the plugin and unregister hooks."""
+        try:
+            self.api.hooks.unregister_all_hooks(self.plugin_id)
+            return True
+        except Exception as e:
+            self.api.logger.error(
+                f"Failed to deactivate Quick Search plugin: {e}"
+            )
+            return False
 
     def onBrowserStart(self):
         try:

--- a/src/plugins/store_plugins.json
+++ b/src/plugins/store_plugins.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "sample_plugin",
+    "name": "Sample Plugin",
+    "version": "1.0.0",
+    "author": "NebulaFusion Team",
+    "description": "A sample plugin that demonstrates adding a button to the toolbar.",
+    "url": "https://example.com/sample_plugin.zip"
+  }
+]


### PR DESCRIPTION
## Summary
- register hooks in the bundled toolbar and search plugins
- enable plugins before UI is created so hooks fire during startup

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/test_plugin_system.py::TestPluginSystem::test_plugin_manager -vv` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_6844563bef3c8328bcc1ca1a8afcb3dc