### PR TITLE
Minor UI fixes and theme persistence

### DIFF
--- a/src/core/application.py
+++ b/src/core/application.py
@@ -369,6 +369,8 @@ class SettingsManager(QObject):
         # Save settings to QSettings
         for key, value in self.default_settings.items():
             self.settings.setValue(key, value)
+        # Ensure the settings are written to disk
+        self.settings.sync()
 
     def get_setting(self, key, default=None):
         """Get a setting."""

--- a/src/themes/theme_manager.py
+++ b/src/themes/theme_manager.py
@@ -59,7 +59,7 @@ class ThemeManager(QObject):
 
         # Apply default theme
         default_theme = self.app_controller.settings_manager.get_setting(
-            "theme", "Default"
+            "appearance.theme", "Default"
         )
         self.apply_theme(default_theme)
 
@@ -262,7 +262,9 @@ class ThemeManager(QObject):
         self.current_theme = theme_name
 
         # Save theme setting
-        self.app_controller.settings_manager.set_setting("theme", theme_name)
+        self.app_controller.settings_manager.set_setting(
+            "appearance.theme", theme_name
+        )
 
         # Emit signal
         self.theme_changed.emit(theme_name)

--- a/src/ui/address_bar.py
+++ b/src/ui/address_bar.py
@@ -42,6 +42,11 @@ class AddressBar(QLineEdit):
         model = QStringListModel()
         model.setStringList(urls)
         self.completer.setModel(model)
+
+    def focusInEvent(self, event):
+        """Select all text when the widget gains focus."""
+        super().focusInEvent(event)
+        self.selectAll()
     
     def _on_return_pressed(self):
         """Handle return key press."""


### PR DESCRIPTION
## Summary
- ensure theme preference uses the appearance theme key so it persists
- select address bar text on focus for easier editing
- sync settings to disk when saving

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68445d68e6208328bc1188f08601fa68