### PR TITLE
Fix duplicate logging and page attribute

### DIFF
--- a/src/core/application.py
+++ b/src/core/application.py
@@ -59,6 +59,10 @@ class Application(QObject):
         # Create logger
         self.logger = logging.getLogger("NebulaFusion")
         self.logger.setLevel(logging.INFO)
+        # Prevent log messages from being propagated to the root logger which
+        # could result in duplicate log entries when other modules configure
+        # logging as well.
+        self.logger.propagate = False
 
         # Create console handler
         console_handler = logging.StreamHandler()

--- a/src/main.py
+++ b/src/main.py
@@ -18,26 +18,21 @@ from src.core.application import Application
 
 def setup_logging():
     """Set up logging configuration."""
-    # Define the log directory and file path, consistent with Application class
+    # This helper previously configured the root logger which caused duplicate
+    # messages when the Application class added its own handlers. It now simply
+    # ensures the log directory exists so Application can handle configuration
+    # itself.
     log_dir = os.path.expanduser("~/.nebulafusion/logs")
-    # Create the log directory if it doesn't exist
     os.makedirs(log_dir, exist_ok=True)
-    log_file_path = os.path.join(log_dir, "nebulafusion.log")
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[
-            logging.StreamHandler(),
-            logging.FileHandler(log_file_path),  # Use the full path
-        ],
-    )
 
 
 def global_exception_hook(exctype, value, tb):
     """Global exception handler to log uncaught exceptions and show a dialog."""
     error_msg = ''.join(traceback.format_exception(exctype, value, tb))
-    logging.critical(f"Uncaught exception:\n{error_msg}")
+    # Use the application logger if available so the message ends up in the
+    # same log file as other entries.
+    logger = logging.getLogger("NebulaFusion")
+    logger.critical(f"Uncaught exception:\n{error_msg}")
     try:
         # Show a user-friendly error dialog if possible
         QMessageBox.critical(None, "Critical Error", f"An unexpected error occurred. See log for details.\n\n{value}")

--- a/src/ui/browser_tabs.py
+++ b/src/ui/browser_tabs.py
@@ -39,9 +39,11 @@ class BrowserTab(QWebEngineView):
             # Use default profile
             self.profile = self.app_controller.web_engine_manager.get_default_profile()
 
-        # Create web page
-        self.page = QWebEnginePage(self.profile, self)
-        self.setPage(self.page)
+        # Create web page. Avoid storing it under the name "page" since
+        # QWebEngineView already provides a method with that name. Using a
+        # separate attribute prevents accidental shadowing and call errors.
+        self.web_page = QWebEnginePage(self.profile, self)
+        self.setPage(self.web_page)
 
         # Connect signals
         self._connect_signals()
@@ -137,7 +139,7 @@ class BrowserTab(QWebEngineView):
 
     def save_page(self, file_path):
         """Save page to file."""
-        self.page.save(file_path)
+        self.web_page.save(file_path)
 
     def print_page(self):
         """Print page."""


### PR DESCRIPTION
## Summary
- prevent log propagation to avoid duplicate messages
- tweak log setup helper and global exception logger
- rename BrowserTab `page` attribute to `web_page`

## Testing
- `pytest -q` *(fails: ImportError libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68449590fac88328a43ab12b865d1eb5