### PR TITLE
Add download hook support

### DIFF
--- a/src/core/downloads.py
+++ b/src/core/downloads.py
@@ -168,7 +168,7 @@ class DownloadManager(QObject):
             self.download_started.emit(download_id, url)
             
             # Trigger hook
-            self.app_controller.hook_registry.trigger_hook("onDownloadStarted", download_id, url, download_path)
+            self.app_controller.hook_registry.trigger_hook("onDownloadStart", download_id, url, download_path)
             
             self.app_controller.logger.info(f"Download started: {url} to {download_path}")
             
@@ -260,7 +260,7 @@ class DownloadManager(QObject):
             self.download_finished.emit(download_id, path)
             
             # Trigger hook
-            self.app_controller.hook_registry.trigger_hook("onDownloadFinished", download_id, path)
+            self.app_controller.hook_registry.trigger_hook("onDownloadComplete", download_id, path)
             
             self.app_controller.logger.info(f"Download finished: {path}")
         
@@ -337,7 +337,7 @@ class DownloadManager(QObject):
                 self.download_failed.emit(download_id, error)
                 
                 # Trigger hook
-                self.app_controller.hook_registry.trigger_hook("onDownloadFailed", download_id, error)
+                self.app_controller.hook_registry.trigger_hook("onDownloadError", download_id, error)
                 
                 self.app_controller.logger.info(f"Download failed: {download_id} - {error}")
         

--- a/src/plugins/hook_registry.py
+++ b/src/plugins/hook_registry.py
@@ -41,8 +41,15 @@ class HookRegistry(QObject):
             # Navigation hooks
             "onUrlChanged",
             # Download hooks
-            "onDownloadStarted",
-            "onDownloadFinished",
+            "onDownloadStart",
+            "onDownloadProgress",
+            "onDownloadComplete",
+            "onDownloadError",
+            "onDownloadCanceled",
+            "onDownloadPaused",
+            "onDownloadResumed",
+            "onDownloadsCleared",
+            "onDownloadRemoved",
             # Bookmark hooks
             "onBookmarkAdded",
             "onBookmarkRemoved",

--- a/src/ui/plugin_dialog.py
+++ b/src/ui/plugin_dialog.py
@@ -265,8 +265,11 @@ Available Hooks:
 - onPageLoading: Called when a page starts loading
 - onPageLoaded: Called when a page finishes loading
 - onUrlChanged: Called when URL changes
-- onDownloadStarted: Called when a download starts
-- onDownloadFinished: Called when a download finishes
+- onDownloadStart: Called when a download starts
+- onDownloadProgress: Called during download progress
+- onDownloadComplete: Called when a download completes
+- onDownloadError: Called when a download fails
+- onDownloadCanceled: Called when a download is canceled
 - onBookmarkAdded: Called when a bookmark is added
 - onBookmarkRemoved: Called when a bookmark is removed
 - onHistoryAdded: Called when a history entry is added


### PR DESCRIPTION
## Summary
- expose detailed download hooks in `HookRegistry`
- trigger new hook names from `DownloadManager`
- document new hooks in the plugin dialog help

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844a631a1708328880fe1af136d4c6a